### PR TITLE
Correct erb tags to render index page correctly

### DIFF
--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -1,5 +1,5 @@
 <ul>  
-  <%= cart.each do |product| %>
+  <% cart.each do |product| %>
     <li><%= product %></li>
   <% end %>
 </ul>


### PR DESCRIPTION
Quick fix - an unnecessary equals sign caused the shopping cart to render incorrectly.